### PR TITLE
Refactor many small issue fixes

### DIFF
--- a/flask_tus/app.py
+++ b/flask_tus/app.py
@@ -5,7 +5,6 @@ import datetime
 
 from flask import request, current_app
 
-import flask_tus.responses as Response
 from .utilities import extract_metadata
 from .exceptions import TusError
 from .repositories import Repo

--- a/flask_tus/app.py
+++ b/flask_tus/app.py
@@ -34,7 +34,7 @@ class FlaskTus(object):
         app.register_error_handler(TusError, TusError.error_handler)
 
         app.add_url_rule(app.config['TUS_UPLOAD_URL'], 'create_upload',
-                         self.create_upload, methods=['OPTIONS', 'POST'])
+                         self.create_upload, methods=['OPTIONS', 'POST'], strict_slashes=False)
         app.add_url_rule(app.config['TUS_UPLOAD_URL'] + '<upload_uuid>',
                          'modify_upload', self.modify_upload, methods=['HEAD', 'PATCH', 'DELETE'])
 

--- a/flask_tus/app.py
+++ b/flask_tus/app.py
@@ -18,12 +18,13 @@ from .validators import (validate_post, validate_head,
 class FlaskTus(object):
     def __init__(self, app=None, model=None, db=None, repo=None):
         if app:
-            self.app = app
             self.init_app(app, model, db, repo)
 
     # Application factory
 
     def init_app(self, app, model, db=None, repo=None):
+        self.app = app
+
         app.config.setdefault('TUS_UPLOAD_DIR', tempfile.mkdtemp())
         app.config.setdefault('TUS_UPLOAD_URL', '/files/')
         app.config.setdefault('TUS_MAX_SIZE', 2**32)  # 4 GB

--- a/flask_tus/exceptions.py
+++ b/flask_tus/exceptions.py
@@ -19,10 +19,7 @@ class TusError(Exception):
             raise error
 
         if error.throw_as == 'Header':
-            response = make_base_response(error.status_code)
-            response.message = error.message
-            response.status_code = error.status_code
-
+            response = make_base_response(error.status_code, error.message)
             return response
 
         if error.throw_as == 'JSON':

--- a/flask_tus/repositories/mongoengine_repository.py
+++ b/flask_tus/repositories/mongoengine_repository.py
@@ -14,7 +14,7 @@ class MongoengineRepository(BaseRepository):
         super(MongoengineRepository, self).__init__(model, db)
 
     def create(self, *args, **kwargs):
-        return self.model.objects.create(*args, **kwargs)
+        return self.model.objects.create(**kwargs)
 
     def find_by(self, *args,  **kwargs):
         return self.model.objects.filter(*args, **kwargs)

--- a/flask_tus/responses.py
+++ b/flask_tus/responses.py
@@ -26,6 +26,9 @@ def post_response(upload):
     else:
         response.headers['Upload-Length'] = upload.length
 
+    if upload.offset > 0 and upload.offset != upload.length:
+        response.headers['Upload-Offset'] = upload.offset
+
     # The Server MUST set the Location header to the URL of the created resource. This URL MAY be absolute or relative.
     response.headers['location'] = current_app.config['TUS_UPLOAD_URL'] + str(upload.upload_uuid)
 

--- a/flask_tus/validators.py
+++ b/flask_tus/validators.py
@@ -24,7 +24,7 @@ def validate_patch(upload):
     # If a Client does attempt to resume an upload which has since been removed by the Server,
     # the Server SHOULD respond with the 404 Not Found or 410 Gone status.
     if upload.expired:
-        raise TusError(410)
+        raise TusError(410, 'upload expired')
 
     # All PATCH requests MUST use Content-Type: application/offset+octet-stream, otherwise the server SHOULD return a
     # 415 Unsupported Media Type status.


### PR DESCRIPTION
I fixed several issues I discovered.

- fixed: header Upload-Offset was missing so resumability did not worked
- fixed: flask application factory pattern did not worked using initialising of flask-tus with init_app - fixed
-  fixed: if client send request for upload endpoint without trailing slash upload did failed
- fixed: passing error message to make_base_response
- in case that upload failed because it expired added message to the error
- fixed: mongoengine parameters for model.create were incorrect it does not accept positional parameters: http://docs.mongoengine.org/apireference.html#mongoengine.queryset.QuerySet.create